### PR TITLE
Fix multi index union

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,6 @@
 name: CI
 on: [push]
 
-env:
-  CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-  # `github.ref` points to the *merge commit* when running tests on a pull request, which will be a commit
-  # that doesn't exists in our code base. Since this workflow triggers from a PR, we use the HEAD SHA instead.
-  #
-  # NOTE: These are both used by Code Climate (cc-test-reporter).
-  GIT_COMMIT_SHA: ${{github.event.pull_request.head.sha}}
-  GIT_BRANCH: ${{github.head_ref}}
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: "Download cc-test-reporter from codeclimate.com"
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-    - name: "Report to Code Climate that we will send a coverage report."
-      run: ./cc-test-reporter before-build
     - name: Run tests
       run: bundle exec rspec
-    - name: Upload code coverage to Code Climate
-      run: |
-        ./cc-test-reporter after-build \
-          --coverage-input-type simplecov \
-          ./coverage/.resultset.json

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -80,7 +80,7 @@ Naming/MethodParameterName:
 # ForbiddenPrefixes: is_, has_, have_
 # AllowedMethods: is_a?
 # MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - 'spec/**/*'
     - 'lib/daru_lite/data_frame/missable.rb'

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Simple, straightforward DataFrames for Ruby
 
 [![Build Status](https://github.com/pollandroll/daru_lite/actions/workflows/build.yml/badge.svg)](https://github.com/pollandroll/daru_lite/actions)
 [![Gem Version](https://img.shields.io/gem/v/daru_lite.svg)](https://rubygems.org/gems/daru_lite)
-[![Maintainability](https://api.codeclimate.com/v1/badges/f87d4ed10b5731e50184/maintainability)](https://codeclimate.com/github/pollandroll/daru_lite/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/f87d4ed10b5731e50184/test_coverage)](https://codeclimate.com/github/pollandroll/daru_lite/test_coverage)
 
 ## Introduction
 

--- a/lib/daru_lite/data_frame/joinable.rb
+++ b/lib/daru_lite/data_frame/joinable.rb
@@ -22,7 +22,10 @@ module DaruLite
         df = row[*(@index.to_a - other_df.index.to_a)]
 
         df = df.concat(other_df)
-        df.index = DaruLite::Index.new(index)
+        df.index = @index.class.public_send(
+          @index.is_a?(DaruLite::MultiIndex) ? :from_tuples : :new,
+          index
+        )
         df
       end
 

--- a/lib/daru_lite/index/index.rb
+++ b/lib/daru_lite/index/index.rb
@@ -229,7 +229,7 @@ module DaruLite
     #   #     2  false
     #   #     3  false
     #   #     4  true
-    def is_values(*indexes) # rubocop:disable Naming/PredicateName
+    def is_values(*indexes) # rubocop:disable Naming/PredicatePrefix
       bool_array = @keys.map { |r| indexes.include?(r) }
       DaruLite::Vector.new(bool_array)
     end

--- a/lib/daru_lite/index/multi_index.rb
+++ b/lib/daru_lite/index/multi_index.rb
@@ -122,8 +122,10 @@ module DaruLite
     end
 
     def [](*key)
-      key.flatten!
-      if key[0].is_a?(Range)
+      if key[0].is_a?(Array)
+        collection = key.map { |actual_key| self[*actual_key] }
+        collection.one? ? collection.first : collection
+      elsif key[0].is_a?(Range)
         retrieve_from_range(key[0])
       elsif key[0].is_a?(Integer) && key.size == 1
         try_retrieve_from_integer(key[0])
@@ -158,7 +160,7 @@ module DaruLite
 
         return indexes
       end
-      res = self[indexes]
+      res = self[*indexes]
       return res if res.is_a? Integer
 
       res.map { |i| self[i] }

--- a/lib/daru_lite/index/multi_index.rb
+++ b/lib/daru_lite/index/multi_index.rb
@@ -169,7 +169,7 @@ module DaruLite
     def subset(*indexes)
       if indexes.first.is_a? Integer
         MultiIndex.from_tuples(indexes.map { |index| key(index) })
-      elsif include? indexes.first
+      elsif indexes.first.is_a?(Array) && include?(indexes.first)
         # Same logic as in DaruLite::Index#subset
         MultiIndex.from_tuples indexes
       else

--- a/lib/daru_lite/index/multi_index.rb
+++ b/lib/daru_lite/index/multi_index.rb
@@ -169,6 +169,9 @@ module DaruLite
     def subset(*indexes)
       if indexes.first.is_a? Integer
         MultiIndex.from_tuples(indexes.map { |index| key(index) })
+      elsif include? indexes.first
+        # Same logic as in DaruLite::Index#subset
+        MultiIndex.from_tuples indexes
       else
         self[indexes].conform indexes
       end

--- a/lib/daru_lite/index/multi_index.rb
+++ b/lib/daru_lite/index/multi_index.rb
@@ -167,9 +167,10 @@ module DaruLite
     end
 
     def subset(*indexes)
-      if indexes.first.is_a? Integer
+      first_index = indexes.first
+      if first_index.is_a? Integer
         MultiIndex.from_tuples(indexes.map { |index| key(index) })
-      elsif indexes.first.is_a?(Array) && include?(indexes.first)
+      elsif first_index.is_a?(Array) && include?(first_index)
         # Same logic as in DaruLite::Index#subset
         MultiIndex.from_tuples indexes
       else

--- a/lib/daru_lite/vector/indexable.rb
+++ b/lib/daru_lite/vector/indexable.rb
@@ -15,7 +15,7 @@ module DaruLite
       end
 
       # Returns *true* if an index exists
-      def has_index?(index) # rubocop:disable Naming/PredicateName
+      def has_index?(index) # rubocop:disable Naming/PredicatePrefix
         @index.include? index
       end
 

--- a/lib/daru_lite/vector/missable.rb
+++ b/lib/daru_lite/vector/missable.rb
@@ -4,7 +4,7 @@ module DaruLite
       extend Gem::Deprecate
 
       # Reports whether missing data is present in the Vector.
-      def has_missing_data? # rubocop:disable Naming/PredicateName
+      def has_missing_data? # rubocop:disable Naming/PredicatePrefix
         !indexes(*DaruLite::MISSING_VALUES).empty?
       end
       alias flawed? has_missing_data?

--- a/spec/data_frame/joinable_example.rb
+++ b/spec/data_frame/joinable_example.rb
@@ -41,7 +41,7 @@ shared_examples_for 'a joinable DataFrame' do
   end
 
 
-  context "#union" do
+  describe "#union" do
     let(:df1) do
       DaruLite::DataFrame.new({
         a: [1, 2, 3],
@@ -64,43 +64,59 @@ shared_examples_for 'a joinable DataFrame' do
       )
     end
 
-    it 'does not modify the original dataframes' do
-      df1_a = df1[:a].to_a.dup
-      df2_a = df2[:a].to_a.dup
+    shared_examples_for '#union' do
+      it 'does not modify the original dataframes' do
+        df1_a = df1[:a].to_a.dup
+        df2_a = df2[:a].to_a.dup
 
-      _ = df1.union df2
-      expect(df1[:a].to_a).to eq df1_a
-      expect(df2[:a].to_a).to eq df2_a
+        _ = df1.union df2
+        expect(df1[:a].to_a).to eq df1_a
+        expect(df2[:a].to_a).to eq df2_a
+      end
+
+      it 'creates a new dataframe that is a concatenation of the two dataframe arguments' do
+        df1_a = df1[:a].to_a.dup
+        df2_a = df2[:a].to_a.dup
+
+        df_union = df1.union df2
+        expect(df_union[:a].to_a).to eq df1_a + df2_a
+      end
+
+      it 'fills in missing vectors with nils' do
+        df1_b = df1[:b].to_a.dup
+        df2_c = df2[:c].to_a.dup
+
+        df_union = df1.union df2
+        expect(df_union[:b].to_a).to eq df1_b + [nil] * df2.size
+        expect(df_union[:c].to_a).to eq [nil] * df1.size + df2_c
+      end
+
+      it 'overwrites part of the first dataframe if there are double indices' do
+        vec = DaruLite::Vector.new({a: 4, b: nil, c: 4})
+        expect(df1.union(df3).row[5]).to eq vec
+      end
+
+      it 'concats the indices' do
+        v1 = df1.index.to_a
+        v2 = df2.index.to_a
+
+        df_union = df1.union df2
+        expect(df_union.index.to_a).to eq v1 + v2
+      end
     end
 
-    it 'creates a new dataframe that is a concatenation of the two dataframe arguments' do
-      df1_a = df1[:a].to_a.dup
-      df2_a = df2[:a].to_a.dup
-
-      df_union = df1.union df2
-      expect(df_union[:a].to_a).to eq df1_a + df2_a
+    context 'with regular index' do
+      it_behaves_like '#union'
     end
 
-    it 'fills in missing vectors with nils' do
-      df1_b = df1[:b].to_a.dup
-      df2_c = df2[:c].to_a.dup
+    context 'with multi index' do
+      before do
+        df1.index = DaruLite::MultiIndex.from_tuples([[:a, 1],[:b, 3],[:c, 5]])
+        df2.index = DaruLite::MultiIndex.from_tuples([[:a, 7],[:b, 9],[:c, 11]])
+        df3.index = DaruLite::MultiIndex.from_tuples([[:c, 5],[:a, 7],[:b, 9]])
+      end
 
-      df_union = df1.union df2
-      expect(df_union[:b].to_a).to eq df1_b + [nil] * df2.size
-      expect(df_union[:c].to_a).to eq [nil] * df1.size + df2_c
-    end
-
-    it 'overwrites part of the first dataframe if there are double indices' do
-      vec = DaruLite::Vector.new({a: 4, b: nil, c: 4})
-      expect(df1.union(df3).row[5]).to eq vec
-    end
-
-    it 'concats the indices' do
-      v1 = df1.index.to_a
-      v2 = df2.index.to_a
-
-      df_union = df1.union df2
-      expect(df_union.index.to_a).to eq v1 + v2
+      it_behaves_like '#union'
     end
   end
 end

--- a/spec/data_frame/joinable_example.rb
+++ b/spec/data_frame/joinable_example.rb
@@ -45,22 +45,19 @@ shared_examples_for 'a joinable DataFrame' do
     let(:df1) do
       DaruLite::DataFrame.new({
         a: [1, 2, 3],
-        b: [1, 2, 3]},
-        index: [1,3,5]
+        b: [1, 2, 3]}
       )
     end
     let(:df2) do
       DaruLite::DataFrame.new({
         a: [4, 5, 6],
-        c: [4, 5, 6]},
-        index: [7,9,11]
+        c: [4, 5, 6]}
       )
     end
     let(:df3) do
       DaruLite::DataFrame.new({
         a: [4, 5, 6],
-        c: [4, 5, 6]},
-        index: [5,7,9]
+        c: [4, 5, 6]}
       )
     end
 
@@ -93,7 +90,7 @@ shared_examples_for 'a joinable DataFrame' do
 
       it 'overwrites part of the first dataframe if there are double indices' do
         vec = DaruLite::Vector.new({a: 4, b: nil, c: 4})
-        expect(df1.union(df3).row[5]).to eq vec
+        expect(df1.union(df3).row[df1_df3_common_indice]).to eq vec
       end
 
       it 'concats the indices' do
@@ -106,14 +103,26 @@ shared_examples_for 'a joinable DataFrame' do
     end
 
     context 'with regular index' do
+      let(:df1_df3_common_indice) { 5 }
+      let(:df2_df3_common_indices) { [7, 9] }
+
+      before do
+        df1.index = [1, 3, df1_df3_common_indice]
+        df2.index = [*df2_df3_common_indices, 11]
+        df3.index = [df1_df3_common_indice, *df2_df3_common_indices]
+      end
+
       it_behaves_like '#union'
     end
 
     context 'with multi index' do
+      let(:df1_df3_common_indice) { [:c, 5] }
+      let(:df2_df3_common_indices) { [[:a, 7],[:b, 9]] }
+
       before do
-        df1.index = DaruLite::MultiIndex.from_tuples([[:a, 1],[:b, 3],[:c, 5]])
-        df2.index = DaruLite::MultiIndex.from_tuples([[:a, 7],[:b, 9],[:c, 11]])
-        df3.index = DaruLite::MultiIndex.from_tuples([[:c, 5],[:a, 7],[:b, 9]])
+        df1.index = DaruLite::MultiIndex.from_tuples([[:a, 1], [:b, 3], df1_df3_common_indice])
+        df2.index = DaruLite::MultiIndex.from_tuples([*df2_df3_common_indices, [:c, 11]])
+        df3.index = DaruLite::MultiIndex.from_tuples([df1_df3_common_indice, *df2_df3_common_indices])
       end
 
       it_behaves_like '#union'

--- a/spec/index/multi_index_spec.rb
+++ b/spec/index/multi_index_spec.rb
@@ -141,6 +141,10 @@ describe DaruLite::MultiIndex do
       expect(index[:a, :one, :baz]).to eq(1)
     end
 
+    it "returns the row numbers when specifying multiple tuples" do
+      expect(index[[:a, :one, :baz], [:b, :two, :bar]]).to eq([1, 5])
+    end
+
     it "returns MultiIndex when specifying incomplete tuple" do
       expect(index[:b]).to eq(DaruLite::MultiIndex.from_tuples([
         [:b,:one,:bar],
@@ -523,6 +527,14 @@ describe DaruLite::MultiIndex do
       it { is_expected.to eq [0, 1] }
     end
 
+    context "multiple tuple indexes" do
+      subject { idx.pos [:b,:two,:bar], [:b,:one,:foo] }
+
+      it { is_expected.to be_a Array }
+      its(:size) { is_expected.to eq 2 }
+      it { is_expected.to eq [1, 3] }
+    end
+
     # TODO: Add specs for IndexError
   end
 
@@ -550,6 +562,14 @@ describe DaruLite::MultiIndex do
       it { is_expected.to be_a described_class }
       its(:size) { is_expected.to eq 2 }
       its(:to_a) { is_expected.to eq [[:b, :one, :bar], [:b, :two, :bar]] }
+    end
+
+    context "multiple tuple indexes" do
+      subject { idx.subset [:b,:two,:bar], [:b,:one,:foo] }
+
+      it { is_expected.to be_a described_class }
+      its(:size) { is_expected.to eq 2 }
+      its(:to_a) { is_expected.to eq [[:b,:two,:bar], [:b,:one,:foo]] }
     end
 
     # TODO: Checks for invalid indexes


### PR DESCRIPTION
J'en ai profité pour retirer codeclimate et renommer un cop rubocop déprécié. Mais pour le reste des offenses rubocop il y en a tellement qu'à mon avis il vaut mieux ouvrir une autre PR plutôt que de polluer celle-ci.