### PR TITLE
Fix NoMethodError on single-key lookup with a CategoricalIndex

### DIFF
--- a/lib/daru_lite/index/categorical_index.rb
+++ b/lib/daru_lite/index/categorical_index.rb
@@ -65,6 +65,22 @@ module DaruLite
       positions.size == 1 ? positions.first : positions.sort
     end
 
+    # Returns the position(s) of the given category/categories or position(s).
+    # Mirrors Index#[] but resolves against the categorical structure
+    # (@cat_hash / @array) instead of @relation_hash, which CategoricalIndex
+    # never populates.
+    # @param keys [Array<object>] categories or positions to look up
+    # @return [Integer, Array<Integer>, nil] position(s), or nil if absent
+    # @example
+    #   idx = DaruLite::CategoricalIndex.new [:a, :b, :a]
+    #   idx[:b]   # => 1
+    #   idx[:z]   # => nil
+    def [](*keys)
+      pos(*keys)
+    rescue IndexError
+      nil
+    end
+
     # Returns index value from position
     # @param pos [Integer] the position to look for
     # @return [object] category corresponding to position

--- a/lib/daru_lite/version.rb
+++ b/lib/daru_lite/version.rb
@@ -1,3 +1,3 @@
 module DaruLite
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -886,6 +886,23 @@ describe DaruLite::DataFrame do
       expect(df).to eq(DaruLite::DataFrame.new({b: [11,12,14,15], a: [1,2,4,5],
       c: [11,22,44,55]}, order: [:a, :b, :c], index: [:one, :two, :four, :five]))
     end
+
+    context "when the data frame has a CategoricalIndex" do
+      let(:categorical_df) do
+        frame = DaruLite::DataFrame.new(
+          { a: [1, 2, 3], b: [11, 22, 33] },
+          order: [:a, :b],
+          index: [:base, :one, :two]
+        )
+        frame.index = DaruLite::CategoricalIndex.new([:base, :one, :two])
+        frame
+      end
+
+      it "deletes the specified row without raising" do
+        expect { categorical_df.delete_row :base }.not_to raise_error
+        expect(categorical_df.index.to_a).to eq [:one, :two]
+      end
+    end
   end
 
   context "#rename_vectors!" do

--- a/spec/index/categorical_index_spec.rb
+++ b/spec/index/categorical_index_spec.rb
@@ -68,6 +68,38 @@ describe DaruLite::CategoricalIndex do
     end
   end
 
+  describe "#[]" do
+    context "when the category occurs once" do
+      subject { index[:b] }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "when the category occurs multiple times" do
+      subject { index[:a] }
+
+      it { is_expected.to eq [0, 2, 3] }
+    end
+
+    context "when given a positional index" do
+      subject { index[0] }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "when given multiple categories" do
+      subject { index[:a, :c] }
+
+      it { is_expected.to eq [0, 2, 3, 4] }
+    end
+
+    context "when the category is absent" do
+      subject { index[:z] }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   context "#subset" do
     let(:idx) { described_class.new [:a, 1, :a, 1, :c] }
 


### PR DESCRIPTION
## Summary

`DaruLite::CategoricalIndex` crashes with `NoMethodError: undefined method 'key?' for nil` on any single-key lookup (`index[:label]`).

This was hit via `DataFrame#delete_row` on a categorical-indexed frame

## Root cause

- `Index#initialize` (`lib/daru_lite/index/index.rb:67-73`) builds `@relation_hash`, which every inherited lookup method relies on.
- `CategoricalIndex#initialize` builds its own `@cat_hash`/`@array` and **never calls `super`**, so `@relation_hash` stays `nil`.
- `CategoricalIndex` did **not** override `[]` / `by_single_key`, so a label lookup fell through to `Index#by_single_key` → `@relation_hash.key?(key)` → **NoMethodError**.

Crash path: `DataFrame#delete_row(:base)` → `Vector#delete_at(idx)` → `@index[idx]` → `Index#[]` → `by_single_key` → nil `@relation_hash`.

## Why not just call `super`?

`Index#initialize` does `index.each_with_index.to_h`, which **collapses duplicate categories** — but a `CategoricalIndex` explicitly allows duplicates (e.g. `[:a, 1, :a, 1, :c]`). Populating `@relation_hash` that way would silently return wrong positions. The categorical structure (`@cat_hash`/`@array`) is the correct source of truth.

## Fix

Override `CategoricalIndex#[]` to resolve against the categorical structure by reusing the existing, tested `#pos`, mapping its `IndexError` (unknown key) to `nil` to honour `Index#[]`'s "nil on miss" contract. `#pos` already returns a single `Integer` for a unique match, a sorted `Array` for duplicates, and treats numerics as positions.

Also bumps the version to `0.3.2` so the fix can be released and consumed.

## Tests

- New `#[]` examples in `spec/index/categorical_index_spec.rb` (single/duplicate/positional/multiple/absent).
- New regression context in `spec/dataframe_spec.rb#delete_row` reproducing the exact production crash; fails on `master`, passes here.
- Full suite green (`2373 examples, 0 failures`), RuboCop clean.

## Known follow-up (out of scope)

Other inherited `Index` methods that touch `@relation_hash` (`slice`, `by_range`, `numeric_pos`, `preprocess_range`, `subset_slice`, `key`) remain latently broken on a `CategoricalIndex` and deserve a tracked follow-up (tracked in #48). This PR fixes the single-key lookup path that caused the production error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
